### PR TITLE
Support getting the next word.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -347,4 +347,7 @@ mod test {
         let error = io_template.next_char();
         assert!(error.is_err());
     }
+
+    // TODO: Add some tests for mixing the functions together. This is where I
+    // think problems might pop up.
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -162,6 +162,10 @@ impl IOTemplate {
         }
     }
 
+    pub fn next_word(&mut self) -> Result<String, io::Error> {
+        self.next_token::<String>()
+    }
+
     pub fn next_integer(&mut self) -> Result<i64, io::Error> {
         self.next_token::<i64>()
     }
@@ -349,6 +353,18 @@ mod test {
         assert!(error.is_err());
     }
 
-    // TODO: Add some tests for mixing the functions together. This is where I
-    // think problems might pop up.
+    #[test]
+    fn test_next_word() {
+        let mut lines = VecDeque::new();
+        lines.push_back("first line\n".to_string());
+        lines.push_back("second line\n".to_string());
+
+        let mut io_template = IOTemplate::new_with_lines(lines);
+
+        let first_word: String = io_template.next_word().unwrap();
+        assert!(&first_word == "first");
+
+        let second_word: String = io_template.next_word().unwrap();
+        assert!(&second_word == "line");
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,7 +40,11 @@ impl IOTemplate {
     }
 
     fn read_input<R: BufRead>(reader: R) -> VecDeque<String> {
-        reader.lines().map(|line| line.unwrap()).map(|line| line.trim().to_owned()).collect()
+        reader
+            .lines()
+            .map(|line| line.unwrap())
+            .map(|line| line.trim().to_owned())
+            .collect()
     }
 
     pub fn read_everything(&mut self) {
@@ -197,7 +201,8 @@ impl IOTemplate {
                     self.word_position = 0;
                     self.next_char()
                 } else {
-                    let next_character: char = current_word.chars().nth(self.word_position).unwrap();
+                    let next_character: char =
+                        current_word.chars().nth(self.word_position).unwrap();
                     self.word_position += 1;
                     Ok(next_character)
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,8 @@ pub struct IOTemplate {
     current_line: Option<String>,
     /// Tells us which token (word really) we are in, currently.
     cursor: usize,
+    /// Tells us at which character (of the given word) we are.
+    word_position: usize,
 }
 
 impl IOTemplate {
@@ -23,6 +25,7 @@ impl IOTemplate {
             lines: VecDeque::new(),
             current_line: None,
             cursor: 0,
+            word_position: 0,
         }
     }
 
@@ -32,6 +35,7 @@ impl IOTemplate {
             lines,
             current_line: None,
             cursor: 0,
+            word_position: 0,
         }
     }
 
@@ -75,6 +79,7 @@ impl IOTemplate {
             Ok(false)
         } else {
             self.cursor = 0;
+            self.word_position = 0;
             assert!(self.current_line.is_none());
             if self.lines.is_empty() {
                 Err(io::Error::new(
@@ -153,6 +158,10 @@ impl IOTemplate {
     pub fn next_double(&mut self) -> Result<f64, io::Error> {
         self.next_token::<f64>()
     }
+
+    pub fn next_char(&mut self) -> Result<char, io::Error> {
+        Ok('a')
+    }
 }
 
 #[cfg(test)]
@@ -224,5 +233,20 @@ mod test {
 
         let next_line = io_template.next_line().unwrap();
         println!("This is the current line: {next_line}");
+    }
+
+    // TODO: Make this test more comprehensive.
+    #[test]
+    fn test_next_char() {
+        let mut lines = VecDeque::new();
+        lines.push_back("first line\n".to_string());
+        lines.push_back("second line\n".to_string());
+        lines.push_back("1 2 3 4\n".to_string());
+        lines.push_back("5 6 7 8\n".to_string());
+
+        let mut io_template = IOTemplate::new_with_lines(lines);
+
+        let first_character: char = io_template.next_char().unwrap();
+        assert!(first_character == 'f');
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -189,6 +189,7 @@ impl IOTemplate {
                 let current_word_len: usize = current_word.len();
                 if self.word_position >= current_word_len {
                     self.cursor += 1;
+                    self.word_position = 0;
                     self.next_char()
                 } else {
                     let next_character: char = current_word.chars().nth(self.word_position).unwrap();
@@ -313,6 +314,36 @@ mod test {
         assert!(first == 's');
         let second = io_template.next_char().unwrap();
         assert!(second == 'h');
+        let error = io_template.next_char();
+        assert!(error.is_err());
+
+        // Start off again.
+        let mut lines = VecDeque::new();
+        lines.push_back("fst line\n".to_string());
+        lines.push_back("z\n".to_string());
+
+        let mut io_template = IOTemplate::new_with_lines(lines);
+
+        // Let's try to use `next_char()` to exhaust the first line fully. Make
+        // sure here that all the characters are consistent.
+        let first = io_template.next_char().unwrap();
+        assert!(first == 'f');
+        let second = io_template.next_char().unwrap();
+        assert!(second == 's');
+        let third = io_template.next_char().unwrap();
+        assert!(third == 't');
+
+        // Go through the second word.
+        let _ = io_template.next_char();
+        let _ = io_template.next_char();
+        let _ = io_template.next_char();
+        let _ = io_template.next_char();
+
+        // First character on the second line makes sense.
+        let first_character_second_line = io_template.next_char().unwrap();
+        assert!(first_character_second_line == 'z');
+
+        // You cannot call this anymore.
         let error = io_template.next_char();
         assert!(error.is_err());
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -170,6 +170,7 @@ impl IOTemplate {
         self.next_token::<f64>()
     }
 
+    /// Allows the user to get access to the next character in the input.
     pub fn next_char(&mut self) -> Result<char, io::Error> {
         if self.current_line.is_some() {
             let line: &str = &(self.current_line.as_ref().unwrap());


### PR DESCRIPTION
In this PR, the main addition is the addition of a custom function for getting the next word. It turns out that, in Rust, you can call `parse` with `String`; i.e., you are allowed to parse a string and turn that into another string. Therefore, this function that is added (`next_word`) ends up just using what was already there in the library. No new functionality was needed, since one can just call `next_token::<String>()`.